### PR TITLE
feat: check-issues スキルにタスクリスト登録機能を追加

### DIFF
--- a/.claude/skills/check-issues/SKILL.md
+++ b/.claude/skills/check-issues/SKILL.md
@@ -8,3 +8,16 @@ description: Check all repositories defined in repositories.yaml for open issues
 Use the issue-fetcher agent to read repositories.yaml and fetch all open issues from every repository listed there.
 
 Display the results clearly so the user can decide which issues to process next.
+
+## タスクリストへの登録
+
+issueをサマリーとして表示した後、以下の手順でタスクリストへ登録する:
+
+1. `TaskList` を呼び出して既存タスクを確認する
+2. まだタスク化されていないissueのみを対象にする（subject に `<owner>/<repo>#<number>` が含まれるものは重複とみなす）
+3. 対象issueごとに `TaskCreate` でタスクを作成する
+   - **subject**: `<owner>/<repo>#<number>: <title>`
+   - **description**: issueのbodyと対応手順（ブランチ名・コミットメッセージ・PR作成先）を含める
+   - **activeForm**: `<repo>#<number> を実装中`
+   - **metadata**: `{"owner": "<owner>", "repo": "<repo>", "issue_number": <number>, "priority": "<priority>", "labels": [...]}`
+4. 登録結果（新規追加・スキップ）をユーザーに報告する


### PR DESCRIPTION
/check-issues 実行時に取得したissueをTaskCreate で自動登録するよう
SKILL.md を更新。重複チェック・メタデータ付与の手順を追加。