### PR TITLE
feat: リポジトリcloneとgit worktreeでの作業フローを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,19 @@ issueを取得する際は必ずこのファイルを読み込み、全リポジ
 4. issue-analyzer エージェントで分析
 5. issue-implementer エージェントで実装
 
+## Repository Clone & Worktree
+
+issueを実装する前に以下の手順でリポジトリを準備する：
+
+1. ローカルにリポジトリが存在するか確認する（例: `~/dev/<owner>/<repo>`）
+2. 存在しない場合は `gh repo clone <owner>/<repo> ~/dev/<owner>/<repo>` でcloneする
+3. git worktreeで作業ディレクトリを作成する：
+   ```bash
+   cd ~/dev/<owner>/<repo>
+   git worktree add ~/dev/<owner>/<repo>-worktree/<branch-name> -b <branch-name>
+   ```
+4. issue-implementer は worktree のパス内で作業する
+
 ## GitHub CLI Commands
 
 ```bash
@@ -50,3 +63,5 @@ gh issue comment <number> --repo <owner>/<repo> --body "message"
 - 作業ブランチ名: `issue-<owner>-<repo>-<number>-<short-description>`
 - コミットメッセージ: `Fix <owner>/<repo>#<number>: <description>`
 - PRは必ず対象リポジトリに作成し、issueにリンクする
+- 実装作業は必ず git worktree 内で行う（直接mainブランチで作業しない）
+- clone先: `~/dev/<owner>/<repo>`、worktree先: `~/dev/<owner>/<repo>-worktree/<branch-name>`


### PR DESCRIPTION
## Summary

- `repositories.yaml` のissue処理前にリポジトリのclone確認・worktree作成を行う手順を追加
- clone先パス: `~/dev/<owner>/<repo>`
- worktree先パス: `~/dev/<owner>/<repo>-worktree/<branch-name>`
- 実装作業は必ずgit worktree内で行うルールをRulesセクションに追記

## Test plan

- [ ] CLAUDE.md の内容が正しく反映されているか確認
- [ ] issue-implementerがworktreeを使って作業できるか動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)