### PR TITLE
feat: issueワークフローにTaskCreate/TaskUpdate自動更新を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,11 @@ issueを取得する際は必ずこのファイルを読み込み、全リポジ
 1. `repositories.yaml` を読み込んでリポジトリ一覧を取得
 2. 各リポジトリのissueを `priority` 順（high → normal → low）に取得
 3. `labels` に一致するissueのみを対象にする
-4. issue-analyzer エージェントで分析
-5. issue-implementer エージェントで実装
+4. TaskCreate でタスクを登録し、status を `in_progress` に設定する
+5. issue-analyzer エージェントで分析
+6. issue-implementer エージェントで実装
+7. 実装完了後、TaskUpdate でタスクの status を `completed` に更新する
+8. 失敗・スキップした場合は TaskUpdate で status を `failed` に更新する
 
 ## Repository Clone & Worktree
 


### PR DESCRIPTION
## Summary

- issue処理開始時に TaskCreate でタスク登録 + status を in_progress に設定
- 実装完了後に TaskUpdate で status を completed に更新
- 失敗・スキップ時は TaskUpdate で status を failed に更新

## Test plan

- [ ] issueを処理した際にタスクが自動作成されるか確認
- [ ] 完了時に completed、失敗時に failed へ更新されるか確認

Generated with Claude Code