### PR TITLE
feat: check-issuesスキルにチーム自動起動を追加

### DIFF
--- a/.claude/skills/check-issues/SKILL.md
+++ b/.claude/skills/check-issues/SKILL.md
@@ -23,3 +23,18 @@ issueをサマリーとして表示した後、以下の手順でタスクリス
    - **activeForm**: `<repo>#<number> を実装中`
    - **metadata**: `{"owner": "<owner>", "repo": "<repo>", "issue_number": <number>, "priority": "<priority>", "labels": [...]}`
 4. 登録結果（新規追加・スキップ）をユーザーに報告する
+
+## チーム自動起動
+
+新規タスクが1件以上登録された場合、または既存のpendingタスクがある場合、以下の手順で自動処理を開始する:
+
+1. `TeamCreate` でチームを作成する（description: "issue自動処理チーム"）
+2. pendingタスクごとに `Agent` ツールで issue-implementer を起動する
+   - `team_name`: 作成したチーム名
+   - `name`: `implementer-<N>`（N は連番）
+   - `run_in_background`: true
+   - prompt にはタスクの詳細（owner, repo, issue_number, ブランチ名, コミットメッセージ）を含める
+   - promptには「TaskUpdate でタスク #N の status を in_progress・owner を implementer-N に設定してから作業開始すること」を明記する
+   - promptには「完了後は TaskUpdate でタスク status を completed に更新し、SendMessage で team-lead に完了報告すること」を明記する
+3. チームが起動したことをユーザーに報告する
+4. 全 implementer から完了報告を受け取ったら `SendMessage(type: "shutdown_request")` で全員をシャットダウンし、`TeamDelete` でチームを削除する


### PR DESCRIPTION
## Summary
- `/check-issues` 実行時に pending タスクが存在する場合、`TeamCreate` → `issue-implementer` 起動 → バックグラウンド並列処理 → 完了後シャットダウン & `TeamDelete` までを自動化
- 新規タスク登録後または既存 pending タスクがある場合に自動でチームを起動するフローを追加

## Test plan
- [ ] `/check-issues` を実行して新規issueが検出されることを確認
- [ ] チームが自動作成されimplemeterエージェントが起動することを確認
- [ ] 実装完了後にチームが自動削除されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)