### PR TITLE
Fix #7: Security Issues の調査 - READMEにセキュリティセクションを追加

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -26,11 +26,41 @@ repositories:
   - owner: your-org
     repo: your-repo
     labels:
-      - claude       # Issues with this label will be processed
-    priority: high   # high | normal | low
+      - claude              # Issues with this label will be processed
+    priority: high          # high | normal | low
+    allowed_authors:        # Allowed issue authors (omit to allow all authors)
+      - trusted-user
 ```
 
 To make an issue eligible for processing, attach the label specified in `labels` to the issue on GitHub.
+
+Setting `allowed_authors` restricts automatic processing to issues created by the specified users. **Configuring `allowed_authors` is strongly recommended to prevent prompt injection attacks.**
+
+## Security
+
+This system passes the contents of GitHub issues to an AI agent for automatic execution. Malicious third parties may attempt prompt injection attacks by embedding harmful instructions in issues.
+
+### Recommended Mitigations
+
+- **Set `allowed_authors`**: Only process issues created by trusted users
+- **Use `labels` filters**: Only process issues with specific labels (configure label permissions so only repository administrators can apply them)
+- **Regularly review agent actions**: Audit what the agent has executed
+
+### Example `allowed_authors` configuration
+
+```yaml
+repositories:
+  - owner: your-org
+    repo: your-repo
+    labels:
+      - claude
+    priority: normal
+    allowed_authors:
+      - your-username     # Allow only your own account
+      - trusted-teammate  # Add trusted team members
+```
+
+If `allowed_authors` is omitted, issues from all users will be processed. Always configure this setting when using with public repositories.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,41 @@ repositories:
   - owner: your-org
     repo: your-repo
     labels:
-      - claude       # このラベルがついたissueを処理対象にする
-    priority: high   # high | normal | low
+      - claude              # このラベルがついたissueを処理対象にする
+    priority: high          # high | normal | low
+    allowed_authors:        # 処理を許可するissue作成者（省略時は全員を対象）
+      - trusted-user
 ```
 
 issueを処理対象にするには、対象issueに `labels` で指定したラベルをGitHub上で付与してください。
+
+`allowed_authors` を設定すると、指定したユーザーが作成したissueのみを自動処理します。**プロンプトインジェクション攻撃を防ぐため、`allowed_authors` の設定を強く推奨します。**
+
+## セキュリティ
+
+このシステムはGitHub issueの内容をAIエージェントに渡して自動実行します。悪意のある第三者がissueにプロンプトインジェクション攻撃を仕込む可能性があります。
+
+### 推奨される対策
+
+- **`allowed_authors` を設定する**: 信頼できるユーザーが作成したissueのみを処理対象にする
+- **`labels` フィルターを活用する**: 特定のラベルが付いたissueのみを処理する（ラベルはリポジトリ管理者のみが付与できる設定にする）
+- **処理内容を定期的に確認する**: エージェントが実行した内容をレビューする
+
+### `allowed_authors` の設定例
+
+```yaml
+repositories:
+  - owner: your-org
+    repo: your-repo
+    labels:
+      - claude
+    priority: normal
+    allowed_authors:
+      - your-username     # 自分のアカウントのみを許可
+      - trusted-teammate  # 信頼できるチームメンバーを追加
+```
+
+`allowed_authors` を省略した場合は全ユーザーのissueが処理対象になります。パブリックリポジトリで使用する場合は必ず設定してください。
 
 ## 使い方
 


### PR DESCRIPTION
Fixes #7

## 問題

Agentによる自動実行には根本的なセキュリティリスクがあります。悪意のある第三者がGitHub issueにプロンプトインジェクション攻撃を仕込み、不正なコードの実行やデータ漏洩を引き起こす可能性があります。

## 対応内容

- **README.md** と **README.en.md** にセキュリティセクションを追加
- `allowed_authors` の設定方法と具体的な設定例を記載
- プロンプトインジェクション攻撃への対策として以下を推奨事項として文書化：
  - `allowed_authors` で信頼できる作者のみを許可する
  - `labels` フィルターを活用する
  - エージェントの実行内容を定期的に確認する
- パブリックリポジトリで使用する場合は `allowed_authors` を必須設定として警告

## Changes

- `README.md`: セキュリティセクション追加、`allowed_authors` の設定例を記載
- `README.en.md`: 英語版にも同様のセキュリティセクションを追加