### PR TITLE
Fix #13: allowed_authors の強化

### DIFF
--- a/.claude/agents/issue-fetcher/SKILL.md
+++ b/.claude/agents/issue-fetcher/SKILL.md
@@ -10,19 +10,48 @@ model: haiku
 ## Steps
 
 1. `repositories.yaml` を読み込む（プロジェクトルートにある）
-2. `priority` 順（high → normal → low）にリポジトリをソート
-3. 各リポジトリに対して以下を実行：
+2. 現在のGitHubユーザーを取得する：
    ```bash
-   gh issue list \
-     --repo <owner>/<repo> \
-     --state open \
-     --label <label> \
-     --json number,title,author,updatedAt \
-     --limit 20
+   gh api user -q ".login"
    ```
-   ※ `labels` に複数ある場合は最初のラベルを使う（gh CLIは複数ラベルのOR指定不可のため1つずつ実行して重複を除く）
+3. `priority` 順（high → normal → low）にリポジトリをソート
+4. 各リポジトリに対して以下を実行：
 
-4. **作成者フィルタリング**: リポジトリに `allowed_authors` が設定されている場合、`author.login` がリストに含まれるissueのみを対象にする。`allowed_authors` が設定されていない場合は全作成者を対象にする。
+   **`allowed_authors` の決定:**
+   - `allowed_authors` が設定されていない場合: step 2 で取得したユーザー名を `allowed_authors` として使用する
+   - `allowed_authors` が設定されている場合: そのリストをそのまま使用する
+
+   **issueの取得:**
+   - `allowed_authors` に含まれるユーザーが **1名の場合**: `--author` オプションを使用する
+     ```bash
+     gh issue list \
+       --repo <owner>/<repo> \
+       --state open \
+       --label <label> \
+       --author <username> \
+       --json number,title,author,updatedAt \
+       --limit 20
+     ```
+   - `allowed_authors` に含まれるユーザーが **複数の場合**: 各ユーザーごとに `--author` オプションを使ってコマンドを実行し、結果をマージして重複（同じ number）を除く
+     ```bash
+     # ユーザーごとに実行
+     gh issue list \
+       --repo <owner>/<repo> \
+       --state open \
+       --label <label> \
+       --author <username1> \
+       --json number,title,author,updatedAt \
+       --limit 20
+     gh issue list \
+       --repo <owner>/<repo> \
+       --state open \
+       --label <label> \
+       --author <username2> \
+       --json number,title,author,updatedAt \
+       --limit 20
+     ```
+
+   ※ `labels` に複数ある場合は最初のラベルを使う（gh CLIは複数ラベルのOR指定不可のため1つずつ実行して重複を除く）
 
 5. 結果を以下のフォーマットで出力する：
 

--- a/.claude/skills/check-issues/SKILL.md
+++ b/.claude/skills/check-issues/SKILL.md
@@ -7,7 +7,7 @@ description: Check all repositories defined in repositories.yaml for open issues
 
 Use the issue-fetcher agent to read repositories.yaml and fetch all open issues from every repository listed there.
 
-`allowed_authors` が設定されているリポジトリでは、許可された作成者のissueのみが返される。
+`allowed_authors` が設定されているリポジトリでは、許可された作成者のissueのみが返される。`allowed_authors` が未設定の場合は `gh api user -q ".login"` で取得した現在のユーザーのissueのみが返される。
 
 Display the results clearly so the user can decide which issues to process next.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ repositories:
       - <label to filter>
     priority: high | normal | low
     allowed_authors:        # オプション: 許可する作成者のリスト
-      - <github username>   # 省略した場合は全作成者を対象にする
+      - <github username>   # 省略した場合は gh api user の結果（現在のユーザー）を対象にする
 ```
 
 issueを取得する際は必ずこのファイルを読み込み、全リポジトリを対象にしてください。
@@ -28,7 +28,7 @@ issueを取得する際は必ずこのファイルを読み込み、全リポジ
 1. `repositories.yaml` を読み込んでリポジトリ一覧を取得
 2. 各リポジトリのissueを `priority` 順（high → normal → low）に取得
 3. `labels` に一致するissueのみを対象にする
-4. `allowed_authors` が設定されている場合、その作成者のissueのみを対象にする（未設定の場合は全作成者を対象）
+4. `allowed_authors` が設定されている場合、その作成者のissueのみを対象にする。未設定の場合は `gh api user -q ".login"` で取得した現在のユーザーを対象にする
 5. TaskCreate でタスクを登録し、status を `in_progress` に設定する
 6. issue-analyzer エージェントで分析
 7. issue-implementer エージェントで実装

--- a/example_repositories.yaml
+++ b/example_repositories.yaml
@@ -14,4 +14,4 @@ repositories:
     labels:
       - claude
     priority: normal
-    # allowed_authors を省略した場合は全作成者を対象にする
+    # allowed_authors を省略した場合は gh api user -q ".login" で取得した現在のユーザーを対象にする

--- a/verify_allowed_authors.sh
+++ b/verify_allowed_authors.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# verify_allowed_authors.sh
+# allowed_authors の動作を検証するスクリプト
+#
+# このスクリプトは以下を検証する:
+# 1. gh api user -q ".login" で現在のユーザーが取得できること
+# 2. gh issue list --author オプションでフィルタリングが機能すること
+# 3. repositories.yaml の allowed_authors 設定に応じた動作
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPOSITORIES_YAML="$SCRIPT_DIR/repositories.yaml"
+
+echo "=== allowed_authors 検証スクリプト ==="
+echo ""
+
+# Step 1: 現在のGitHubユーザーを取得
+echo "[Step 1] 現在のGitHubユーザーを取得"
+if ! CURRENT_USER=$(gh api user -q ".login" 2>&1); then
+  echo "  [FAIL] gh api user の実行に失敗しました: $CURRENT_USER"
+  echo "  gh auth login を実行して認証してください。"
+  exit 1
+fi
+echo "  [OK] 現在のユーザー: $CURRENT_USER"
+echo ""
+
+# Step 2: repositories.yaml の読み込み確認
+echo "[Step 2] repositories.yaml の確認"
+if [ ! -f "$REPOSITORIES_YAML" ]; then
+  echo "  [FAIL] repositories.yaml が見つかりません: $REPOSITORIES_YAML"
+  exit 1
+fi
+echo "  [OK] repositories.yaml が存在します"
+echo ""
+
+# Step 3: gh issue list --author オプションの動作確認
+echo "[Step 3] gh issue list --author オプションの動作確認"
+# repositories.yaml から最初のリポジトリを取得してテスト
+FIRST_REPO=$(python3 -c "
+import yaml, sys
+with open('$REPOSITORIES_YAML') as f:
+    data = yaml.safe_load(f)
+repos = data.get('repositories', [])
+if repos:
+    r = repos[0]
+    print(f\"{r['owner']}/{r['repo']}\")
+" 2>/dev/null)
+
+if [ -z "$FIRST_REPO" ]; then
+  echo "  [SKIP] repositories.yaml にリポジトリが定義されていません"
+else
+  echo "  テスト対象リポジトリ: $FIRST_REPO"
+  if gh issue list --repo "$FIRST_REPO" --state open --author "$CURRENT_USER" --json number,title,author --limit 5 &>/dev/null; then
+    echo "  [OK] --author オプションが正常に動作しています"
+  else
+    echo "  [FAIL] --author オプションの実行に失敗しました"
+    exit 1
+  fi
+fi
+echo ""
+
+# Step 4: allowed_authors 設定の確認
+echo "[Step 4] repositories.yaml の allowed_authors 設定確認"
+python3 -c "
+import yaml, sys
+
+with open('$REPOSITORIES_YAML') as f:
+    data = yaml.safe_load(f)
+
+current_user = '$CURRENT_USER'
+repos = data.get('repositories', [])
+
+for repo in repos:
+    owner = repo['owner']
+    name = repo['repo']
+    allowed_authors = repo.get('allowed_authors')
+
+    if allowed_authors is None:
+        effective_authors = [current_user]
+        source = 'gh api user (自動取得)'
+    else:
+        effective_authors = allowed_authors
+        source = 'repositories.yaml'
+
+    print(f'  {owner}/{name}:')
+    print(f'    有効な allowed_authors: {effective_authors} (出典: {source})')
+    if len(effective_authors) == 1:
+        print(f'    gh コマンド: --author {effective_authors[0]} を使用')
+    else:
+        print(f'    gh コマンド: 各ユーザーごとに --author を使って複数回実行')
+    print()
+"
+echo ""
+
+echo "=== 検証完了 ==="
+echo ""
+echo "issue-fetcher エージェントは以下のルールで動作します:"
+echo "  1. allowed_authors が未設定 → gh api user -q '.login' で取得したユーザーを使用"
+echo "  2. allowed_authors が1名 → gh issue list --author <username> で直接フィルタリング"
+echo "  3. allowed_authors が複数 → 各ユーザーごとに gh issue list を実行してマージ"


### PR DESCRIPTION
Fixes #13

## Changes
- `allowed_authors` が未設定の場合、`gh api user -q ".login"` で取得した現在のユーザーを自動的に使用するよう変更
- `gh issue list` 実行時に `--author` オプションでissueフィルタリングを実施
  - `allowed_authors` が1名の場合: `--author <username>` で直接フィルタリング
  - `allowed_authors` が複数の場合: 各ユーザーごとにコマンドを実行し結果をマージ（重複除去）
- `verify_allowed_authors.sh` 検証スクリプトを追加
- `CLAUDE.md` と `example_repositories.yaml` のコメントを更新

## 検証方法
```bash
bash verify_allowed_authors.sh
```