### PR TITLE
Fix #21: .claude/agents/issue-reviewer の名前を変更

### DIFF
--- a/.claude/agents/change-reviewer/SKILL.md
+++ b/.claude/agents/change-reviewer/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: issue-reviewer
+name: change-reviewer
 description: Review code changes for a GitHub issue implementation. Checks if the implementation meets requirements, follows coding standards, and has no security issues. Returns APPROVED or CHANGES_REQUESTED with specific feedback.
 tools: Read, Grep, Glob, Bash
 ---

--- a/.claude/agents/issue-implementer/SKILL.md
+++ b/.claude/agents/issue-implementer/SKILL.md
@@ -11,7 +11,7 @@ issue-analyzer の分析結果をもとにコード変更を実装し、PRを作
 
 - `<owner>/<repo>#<number>` の形式でissueを受け取る
 - issue-analyzer の分析結果（実装計画）を受け取る
-- (再修正の場合) issue-reviewer からのレビュー結果（Required Changes）
+- (再修正の場合) change-reviewer からのレビュー結果（Required Changes）
 
 ## Steps
 
@@ -24,7 +24,7 @@ issue-analyzer の分析結果をもとにコード変更を実装し、PRを作
    - 必ず実装前に対象ファイルを Read して内容を確認する
    - 最小限の変更に留める（over-engineering 禁止）
    - テストコードも追加する
-   - 再修正の場合は issue-reviewer の Required Changes に従って修正する
+   - 再修正の場合は change-reviewer の Required Changes に従って修正する
 
 3. **テスト実行**
    - プロジェクトのテストコマンドを実行して動作確認
@@ -41,9 +41,9 @@ issue-analyzer の分析結果をもとにコード変更を実装し、PRを作
      --body "実装を開始しました。ブランチ: issue-<owner>-<repo>-<number>-..."
    ```
 
-6. **team-lead に実装完了を報告し、issue-reviewer によるレビューを依頼する**
+6. **team-lead に実装完了を報告し、change-reviewer によるレビューを依頼する**
    - 実装が完了したらPRは作成せず、team-lead に実装完了を報告する
-   - team-lead が issue-reviewer エージェントを起動してレビューを行う
+   - team-lead が change-reviewer エージェントを起動してレビューを行う
    - 報告内容には以下を含めること：
      - owner
      - repo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ issueを取得する際は必ずこのファイルを読み込み、全リポジ
 5. TaskCreate でタスクを登録し、status を `in_progress` に設定する
 6. issue-analyzer エージェントで分析
 7. issue-implementer エージェントで実装
-8. issue-reviewer エージェントでコードレビューを行う
+8. change-reviewer エージェントでコードレビューを行う
    - レビューで問題が見つかった場合は issue-implementer エージェントに差し戻して再修正させる
    - 差し戻しと再修正は最大3回まで繰り返す
    - 3回を超えても承認されない場合はスキップとして処理する
@@ -41,7 +41,7 @@ issueを取得する際は必ずこのファイルを読み込み、全リポジ
 
 ## Review Process
 
-issue-reviewer エージェントは以下の観点でコードレビューを行う：
+change-reviewer エージェントは以下の観点でコードレビューを行う：
 
 - issue の要件を満たしているか
 - セキュリティ上の問題がないか（OWASP Top 10 等）


### PR DESCRIPTION
Fixes #21

## Changes
- `.claude/agents/issue-reviewer` を `.claude/agents/change-reviewer` にリネーム
- `change-reviewer/SKILL.md` 内の `name: issue-reviewer` を `name: change-reviewer` に更新
- `CLAUDE.md` 内の `issue-reviewer` 参照を `change-reviewer` に更新
- `issue-implementer/SKILL.md` 内の `issue-reviewer` 参照を `change-reviewer` に更新