### PR TITLE
Fix #18: README を現在のディレクトリ構成に合わせて更新

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -102,11 +102,15 @@ stand-by-me/
 ├── CLAUDE.md                      # Rule definitions for agents
 └── .claude/
     ├── agents/
-    │   ├── issue-fetcher/         # Reads YAML and fetches issue list
-    │   ├── issue-analyzer/        # Analyzes individual issues and creates implementation plans
-    │   └── issue-implementer/     # Implements changes and creates PRs
+    │   ├── issue-fetcher/             # Reads YAML and fetches issue list
+    │   ├── issue-analyzer/            # Analyzes individual issues and creates implementation plans
+    │   ├── issue-implementer/         # Implements changes and creates PRs
+    │   ├── change-reviewer/           # Aggregates review results from specialist reviewers
+    │   ├── implementation-reviewer/   # Reviews implementation correctness and code quality
+    │   ├── security-reviewer/         # Reviews security concerns
+    │   └── consistency-reviewer/      # Reviews test coverage and codebase consistency
     └── skills/
-        └── check-issues/          # Entry point for issue checking
+        └── check-issues/              # Entry point for issue checking
 ```
 
 ## Agent Roles
@@ -116,3 +120,7 @@ stand-by-me/
 | `issue-fetcher` | Reads `repositories.yaml` and fetches issues from all repositories |
 | `issue-analyzer` | Analyzes a specified issue and creates an implementation plan |
 | `issue-implementer` | Applies code changes based on the analysis result and creates a PR |
+| `change-reviewer` | Delegates to three specialist reviewers and aggregates results |
+| `implementation-reviewer` | Verifies issue requirements, code style, and quality |
+| `security-reviewer` | Checks for security issues (OWASP Top 10, etc.) |
+| `consistency-reviewer` | Reviews test coverage and consistency with the existing codebase |

--- a/README.md
+++ b/README.md
@@ -102,11 +102,15 @@ stand-by-me/
 ├── CLAUDE.md                      # エージェントへのルール定義
 └── .claude/
     ├── agents/
-    │   ├── issue-fetcher/         # YAMLを読んでissue一覧を取得
-    │   ├── issue-analyzer/        # 個別issueを分析・計画作成
-    │   └── issue-implementer/     # 実装してPRを作成
+    │   ├── issue-fetcher/             # YAMLを読んでissue一覧を取得
+    │   ├── issue-analyzer/            # 個別issueを分析・計画作成
+    │   ├── issue-implementer/         # 実装してPRを作成
+    │   ├── change-reviewer/           # レビュー結果を集約
+    │   ├── implementation-reviewer/   # 実装内容を確認
+    │   ├── security-reviewer/         # セキュリティを確認
+    │   └── consistency-reviewer/      # コードベースとの整合性を確認
     └── skills/
-        └── check-issues/          # issue確認のエントリポイント
+        └── check-issues/              # issue確認のエントリポイント
 ```
 
 ## エージェントの役割
@@ -116,3 +120,7 @@ stand-by-me/
 | `issue-fetcher` | `repositories.yaml` を読み込み、全リポジトリのissueを取得 |
 | `issue-analyzer` | 指定issueを分析し、実装計画を作成 |
 | `issue-implementer` | 分析結果をもとにコードを変更し、PRを作成 |
+| `change-reviewer` | 3つの専門レビュワーにレビューを委譲し、結果を集約 |
+| `implementation-reviewer` | issue要件の充足・コードスタイル・品質を確認 |
+| `security-reviewer` | セキュリティ上の問題（OWASP Top 10等）を確認 |
+| `consistency-reviewer` | テストの適切さ・コードベースとの整合性を確認 |


### PR DESCRIPTION
Fixes #18

## Changes
- README.md と README.en.md のファイル構成に `change-reviewer`、`implementation-reviewer`、`security-reviewer`、`consistency-reviewer` の4つのエージェントを追加
- エージェント役割テーブルを更新し、新エージェントの説明を追記